### PR TITLE
fixed tests path to src

### DIFF
--- a/tests/integration/Sanitary.test.ts
+++ b/tests/integration/Sanitary.test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import { Sanitary } from "../../lib";
+import { Sanitary } from "../../src";
 
 describe('Sanitary certificate', () => {
     it('Sanitary constructor should throws error with malformed data', () => {

--- a/tests/integration/Vaccination.test.ts
+++ b/tests/integration/Vaccination.test.ts
@@ -1,6 +1,6 @@
 import 'mocha';
 import { expect } from 'chai';
-import { Vaccination } from "../../lib";
+import { Vaccination } from "../../src";
 
 describe('Vaccination certificate', () => {
     it('Vaccination constructor should throws error with malformed data', () => {


### PR DESCRIPTION
Tests were not passing as /lib folder does not exist by default and building the lib should not be required for running tests.